### PR TITLE
fix build after dependency upgrades

### DIFF
--- a/src/main/hardwareWallet.ts
+++ b/src/main/hardwareWallet.ts
@@ -53,8 +53,9 @@ const connectHardwareWallet = async () => {
   for (const service of Object.values(bsAggregator.blockchainServicesByName)) {
     try {
       if (!hasLedger(service)) continue
-      const address = await service.ledgerService.getAddress(transport)
-      const publicKey = await service.ledgerService.getPublicKey(transport)
+      const acc = await service.ledgerService.getAccount(transport, 0)
+      const address = acc.address
+      const publicKey = acc.key
       transporter = {
         address,
         publicKey,

--- a/src/main/walletConnect.ts
+++ b/src/main/walletConnect.ts
@@ -65,7 +65,7 @@ class WalletConnectNeonAdapter extends AbstractWalletConnectNeonAdapter {
     const serviceAccount = service.generateAccountFromPublicKey(key)
     const transport = await getHardwareWalletTransport(serviceAccount)
 
-    return service.ledgerService.getSigningCallback(transport)
+    return service.ledgerService.getSigningCallback(transport, serviceAccount)
   }
 }
 


### PR DESCRIPTION
#206 updated dependencies that have breaking API changes causing the image building not to work. Specifically https://github.com/CityOfZion/blockchain-services/pull/68 removed the `getAddress` and `getPublicKey` functions. Note that I hard coded retrieving account `0`. I currently saw no indication in this function that it should support multiple accounts for Ledgers, but it's something to think about before approving. 